### PR TITLE
Redirect /whatnut to /whatnut/ so CSS resolves

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,12 +10,12 @@
     { "source": "/value-forecasting/:path*", "destination": "https://maxghenis.github.io/value-forecasting/:path*" },
     { "source": "/yankee-stadium-beer-price-controls", "destination": "https://maxghenis.github.io/yankee-stadium-beer-price-controls/" },
     { "source": "/yankee-stadium-beer-price-controls/:path*", "destination": "https://maxghenis.github.io/yankee-stadium-beer-price-controls/:path*" },
-    { "source": "/whatnut", "destination": "https://whatnut-three.vercel.app/whatnut/" },
     { "source": "/whatnut/:path*", "destination": "https://whatnut-three.vercel.app/whatnut/:path*" },
     { "source": "/whatnut-paper", "destination": "https://maxghenis.github.io/whatnut/" },
     { "source": "/whatnut-paper/:path*", "destination": "https://maxghenis.github.io/whatnut/:path*" }
   ],
   "redirects": [
+    { "source": "/whatnut", "destination": "/whatnut/", "permanent": true },
     { "source": "/mita", "destination": "https://mita-iota.vercel.app/", "permanent": false },
     { "source": "/mita/:path*", "destination": "https://mita-iota.vercel.app/:path*", "permanent": false },
     { "source": "/2022/11/california", "destination": "/blog/voter-guides/2022-11-california", "permanent": true },


### PR DESCRIPTION
Quarto emits relative asset URLs like `site_libs/bootstrap/...`. Without a trailing slash on `maxghenis.com/whatnut`, the browser resolves them against `maxghenis.com/` and every CSS/JS file 404s — the paper was shipping unstyled.

Swap the bare `/whatnut` rewrite for a 301 to `/whatnut/`. The `/whatnut/:path*` rewrite still handles every deeper URL.

## Test plan
- [x] Local: confirmed relative paths resolve correctly with trailing slash
- [ ] `curl -I https://maxghenis.com/whatnut` → 301 to `/whatnut/`
- [ ] `https://maxghenis.com/whatnut` in a browser: loads with styling
- [ ] `https://maxghenis.com/whatnut/appendix` still works (uses :path* rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)